### PR TITLE
build(deps): bump ksp from 1.9.24-1.0.20 to 2.0.0-1.0.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 kotlin = "1.9.24"
-ksp = "1.9.24-1.0.20"
+ksp = "2.0.0-1.0.21"
 skiko = "0.0.0-SNAPSHOT"
 junit-jupiter-engine = "5.10.2"
 


### PR DESCRIPTION
Bumps `ksp` from 1.9.24-1.0.20 to 2.0.0-1.0.21.

Updates `com.google.devtools.ksp:symbol-processing-api` from 1.9.24-1.0.20 to 2.0.0-1.0.21
- [Release notes](https://github.com/google/ksp/releases)
- [Commits](https://github.com/google/ksp/compare/1.9.24-1.0.20...2.0.0-1.0.21)

Updates `com.google.devtools.ksp` from 1.9.24-1.0.20 to 2.0.0-1.0.21
- [Release notes](https://github.com/google/ksp/releases)
- [Commits](https://github.com/google/ksp/compare/1.9.24-1.0.20...2.0.0-1.0.21)

---
updated-dependencies:
- dependency-name: com.google.devtools.ksp:symbol-processing-api dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: com.google.devtools.ksp dependency-type: direct:production update-type: version-update:semver-major ...